### PR TITLE
Introduce an HTML-based ItemComparer 

### DIFF
--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/HtmlComparisonContext.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/HtmlComparisonContext.java
@@ -1,0 +1,30 @@
+package org.opentestsystem.ap.itemcompare.comparer.html;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.jsoup.nodes.Document;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparison;
+
+import java.util.Optional;
+
+/**
+ * This model wraps an {@link HtmlComparison} with deserialized HTML documents
+ * representing the HTML differences.
+ */
+@Builder
+@Getter
+public class HtmlComparisonContext {
+
+    private HtmlComparison comparison;
+    private String filename;
+    private Document sourceDocument;
+    private Document testDocument;
+
+    public Optional<Document> getSourceDocument() {
+        return Optional.ofNullable(sourceDocument);
+    }
+
+    public Optional<Document> getTestDocument() {
+        return Optional.ofNullable(testDocument);
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparer.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparer.java
@@ -1,0 +1,90 @@
+package org.opentestsystem.ap.itemcompare.comparer.html;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.opentestsystem.ap.itemcompare.comparer.ItemComparer;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparison;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparisonProvider;
+import org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider;
+import org.opentestsystem.ap.itemcompare.model.ItemComparison;
+import org.opentestsystem.ap.itemcompare.model.ItemDifference;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This comparer performs an HTML comparison on the given items' html text values.
+ */
+@Service
+@Slf4j
+class ItemHtmlComparer implements ItemComparer {
+    static final String NAME = "html";
+
+    private final HtmlComparisonProvider htmlComparisonProvider;
+    private final Set<HtmlDifferenceProvider> differenceProviders;
+
+    @Autowired
+    public ItemHtmlComparer(final HtmlComparisonProvider htmlComparisonProvider,
+                            final Set<HtmlDifferenceProvider> differenceProviders) {
+        this.htmlComparisonProvider = htmlComparisonProvider;
+        this.differenceProviders = differenceProviders;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> getDifferenceTypes() {
+        return Arrays.stream(HtmlDifferenceProvider.DifferenceType.values())
+            .map(HtmlDifferenceProvider.DifferenceType::name)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ItemDifference> compare(final ItemComparison itemComparison) {
+        return htmlComparisonProvider.getComparisons(itemComparison).stream()
+            .map(parseDocuments(itemComparison))
+            .flatMap(getHtmlDifferences())
+            .collect(Collectors.toList());
+    }
+
+    private Function<HtmlComparison, HtmlComparisonContext> parseDocuments(final ItemComparison itemComparison) {
+        return htmlComparison -> {
+            final HtmlComparisonContext.HtmlComparisonContextBuilder builder = HtmlComparisonContext.builder()
+                .comparison(htmlComparison)
+                .filename(itemComparison.getTest().getItemXml().toFile().getName());
+
+            if (htmlComparison.getSourceHtml().isPresent()) {
+                try {
+                    builder.sourceDocument(Jsoup.parseBodyFragment(htmlComparison.getSourceHtml().get()));
+                } catch (final Exception e) {
+                    log.warn("Unable to parse source html for item: [" + itemComparison.getItemId() + "]" +
+                        " location: [" + htmlComparison.getLocation() + "]");
+                }
+            }
+
+            if (htmlComparison.getTestHtml().isPresent()) {
+                try {
+                    builder.testDocument(Jsoup.parseBodyFragment(htmlComparison.getTestHtml().get()));
+                } catch (final Exception e) {
+                    log.warn("Unable to parse test html for item: [" + itemComparison.getItemId() + "]" +
+                        " location: [" + htmlComparison.getLocation() + "]");
+                }
+            }
+            return builder.build();
+        };
+    }
+
+    private Function<HtmlComparisonContext, Stream<ItemDifference>> getHtmlDifferences() {
+        return comparisonDocuments -> differenceProviders.stream()
+            .flatMap(provider -> provider.getDifferences(comparisonDocuments).stream());
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparer.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparer.java
@@ -63,22 +63,13 @@ class ItemHtmlComparer implements ItemComparer {
                 .filename(itemComparison.getTest().getItemXml().toFile().getName());
 
             if (htmlComparison.getSourceHtml().isPresent()) {
-                try {
-                    builder.sourceDocument(Jsoup.parseBodyFragment(htmlComparison.getSourceHtml().get()));
-                } catch (final Exception e) {
-                    log.warn("Unable to parse source html for item: [" + itemComparison.getItemId() + "]" +
-                        " location: [" + htmlComparison.getLocation() + "]");
-                }
+                builder.sourceDocument(Jsoup.parseBodyFragment(htmlComparison.getSourceHtml().get()));
             }
 
             if (htmlComparison.getTestHtml().isPresent()) {
-                try {
-                    builder.testDocument(Jsoup.parseBodyFragment(htmlComparison.getTestHtml().get()));
-                } catch (final Exception e) {
-                    log.warn("Unable to parse test html for item: [" + itemComparison.getItemId() + "]" +
-                        " location: [" + htmlComparison.getLocation() + "]");
-                }
+                builder.testDocument(Jsoup.parseBodyFragment(htmlComparison.getTestHtml().get()));
             }
+
             return builder.build();
         };
     }

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProvider.java
@@ -1,0 +1,97 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Triple;
+import org.eclipse.jgit.util.StringUtils;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.itemcompare.model.ItemComparison;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Default item-type-aware html comparison provider.
+ */
+@Component
+@Slf4j
+class DefaultHtmlComparisonProvider implements HtmlComparisonProvider {
+    private static final Map<String, String> LanguageDisplayMap = ImmutableMap.of(
+        "enu", "English",
+        "esn", "Spanish"
+    );
+
+    private final Set<ItemTypeHtmlComparisonProvider> itemTypeProviders;
+
+    @Autowired
+    public DefaultHtmlComparisonProvider(final Set<ItemTypeHtmlComparisonProvider> itemTypeProviders) {
+        this.itemTypeProviders = itemTypeProviders;
+    }
+
+    @Override
+    public List<HtmlComparison> getComparisons(final ItemComparison itemComparison) {
+        final ItemRelease sourceRelease = itemComparison.getSource().getItemRelease();
+        final ItemRelease testRelease = itemComparison.getTest().getItemRelease();
+        final ItemTypeHtmlComparisonContext context = new ItemTypeHtmlComparisonContext();
+
+        itemTypeProviders.forEach(provider -> provider.appendComparisons(context, sourceRelease, testRelease));
+
+        final ItemRelease.Item sourceItem = sourceRelease.getItem();
+        final ItemRelease.Item testItem = testRelease.getItem();
+        if (sourceItem == null && testItem == null) return context.getComparisons();
+
+        context.setItemType(getFormat(sourceItem, testItem));
+        itemTypeProviders.forEach(provider -> provider.appendComparisons(context, sourceItem, testItem));
+
+        getContentByLanguage(sourceItem, testItem).forEach(triple -> {
+            context.setLanguage(triple.getLeft());
+            itemTypeProviders.forEach(provider -> provider.appendComparisons(context, triple.getMiddle(), triple.getRight()));
+        });
+
+        return context.getComparisons();
+    }
+
+    private String getFormat(final ItemRelease.Item sourceItem, final ItemRelease.Item testItem) {
+        if (testItem != null && isNotBlank(testItem.getFormat())) return testItem.getFormat();
+        if (sourceItem != null && isNotBlank(sourceItem.getFormat())) return sourceItem.getFormat();
+        return "UNKNOWN";
+    }
+
+    private List<Triple<String, ItemRelease.Item.Content, ItemRelease.Item.Content>> getContentByLanguage(final ItemRelease.Item sourceItem, final ItemRelease.Item testItem) {
+        final Map<String, ItemRelease.Item.Content> sourceContentByLanguage = getItemContentByLanguage(sourceItem);
+        final Map<String, ItemRelease.Item.Content> testContentByLanguage = getItemContentByLanguage(testItem);
+
+        return Sets.union(sourceContentByLanguage.keySet(), testContentByLanguage.keySet()).stream()
+            .map(language -> Triple.of(language, sourceContentByLanguage.get(language), testContentByLanguage.get(language)))
+            .collect(Collectors.toList());
+    }
+
+    private Map<String, ItemRelease.Item.Content> getItemContentByLanguage(final ItemRelease.Item item) {
+        if (item == null || item.getContent() == null) return Collections.emptyMap();
+
+        return item.getContent().stream()
+            .collect(Collectors.toMap(
+                this::getLanguage,
+                Functions.identity()
+            ));
+    }
+
+    private String getLanguage(final ItemRelease.Item.Content content) {
+        final String language = content.getLanguage();
+        if (isBlank(language)) {
+            log.warn("ItemRelease.Item.Content without language found. Defaulting to English.");
+            return LanguageDisplayMap.get("enu");
+        }
+        return LanguageDisplayMap.getOrDefault(StringUtils.toLowerCase(language), language);
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProvider.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
@@ -42,16 +42,12 @@ class DefaultHtmlComparisonProvider implements HtmlComparisonProvider {
     public List<HtmlComparison> getComparisons(final ItemComparison itemComparison) {
         final ItemRelease sourceRelease = itemComparison.getSource().getItemRelease();
         final ItemRelease testRelease = itemComparison.getTest().getItemRelease();
-        final ItemTypeHtmlComparisonContext context = new ItemTypeHtmlComparisonContext();
-
-        itemTypeProviders.forEach(provider -> provider.appendComparisons(context, sourceRelease, testRelease));
-
         final ItemRelease.Item sourceItem = sourceRelease.getItem();
         final ItemRelease.Item testItem = testRelease.getItem();
-        if (sourceItem == null && testItem == null) return context.getComparisons();
+        if (sourceItem == null && testItem == null) return emptyList();
 
+        final ItemTypeHtmlComparisonContext context = new ItemTypeHtmlComparisonContext();
         context.setItemType(getFormat(sourceItem, testItem));
-        itemTypeProviders.forEach(provider -> provider.appendComparisons(context, sourceItem, testItem));
 
         getContentByLanguage(sourceItem, testItem).forEach(triple -> {
             context.setLanguage(triple.getLeft());
@@ -87,11 +83,6 @@ class DefaultHtmlComparisonProvider implements HtmlComparisonProvider {
     }
 
     private String getLanguage(final ItemRelease.Item.Content content) {
-        final String language = content.getLanguage();
-        if (isBlank(language)) {
-            log.warn("ItemRelease.Item.Content without language found. Defaulting to English.");
-            return LanguageDisplayMap.get("enu");
-        }
-        return LanguageDisplayMap.getOrDefault(StringUtils.toLowerCase(language), language);
+        return LanguageDisplayMap.getOrDefault(StringUtils.toLowerCase(content.getLanguage()), content.getLanguage());
     }
 }

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProvider.java
@@ -1,0 +1,36 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.springframework.stereotype.Component;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+/**
+ * This comparison provider returns general html fragments common
+ * across multiple item types.
+ */
+@Component
+class GeneralItemTypeHtmlComparisonProvider implements ItemTypeHtmlComparisonProvider {
+
+    @Override
+    public void appendComparisons(final ItemTypeHtmlComparisonContext context,
+                                  final ItemRelease.Item.Content sourceContent,
+                                  final ItemRelease.Item.Content testContent) {
+        appendStem(context, sourceContent, testContent);
+    }
+
+    private void appendStem(final ItemTypeHtmlComparisonContext context,
+                            final ItemRelease.Item.Content sourceContent,
+                            final ItemRelease.Item.Content testContent) {
+        final String sourceStem = sourceContent == null ? null : trimToNull(sourceContent.getStem());
+        final String testStem = testContent == null ? null : trimToNull(testContent.getStem());
+        if (isBlank(sourceStem) && isBlank(testStem)) return;
+
+        context.getComparisons().add(HtmlComparison.builder()
+            .location(context.getLanguage().orElse("") + " Prompt")
+            .sourceHtml(sourceStem)
+            .testHtml(testStem)
+            .build());
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProvider.java
@@ -28,7 +28,7 @@ class GeneralItemTypeHtmlComparisonProvider implements ItemTypeHtmlComparisonPro
         if (isBlank(sourceStem) && isBlank(testStem)) return;
 
         context.getComparisons().add(HtmlComparison.builder()
-            .location(context.getLanguage().orElse("") + " Prompt")
+            .location(context.getLanguage() + " Prompt")
             .sourceHtml(sourceStem)
             .testHtml(testStem)
             .build());

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/HtmlComparison.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/HtmlComparison.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import lombok.Builder;
+
+import java.util.Optional;
+
+/**
+ * This model represents a source and test html body fragment
+ * comparison. (Example: The English Prompt for an item.)
+ */
+@Builder
+public class HtmlComparison {
+
+    private String location;
+    private String sourceHtml;
+    private String testHtml;
+
+    /**
+     * @return The location of the html fragment
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * @return The source item html
+     */
+    public Optional<String> getSourceHtml() {
+        return Optional.ofNullable(sourceHtml);
+    }
+
+    /**
+     * @return The test item html
+     */
+    public Optional<String> getTestHtml() {
+        return Optional.ofNullable(testHtml);
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/HtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/HtmlComparisonProvider.java
@@ -1,0 +1,20 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import org.opentestsystem.ap.itemcompare.model.ItemComparison;
+
+import java.util.List;
+
+/**
+ * Implementations of this interface are reponsible for providing HTML
+ * body fragment pairs between the source and test items.
+ */
+public interface HtmlComparisonProvider {
+
+    /**
+     * Retrieve the html fragment comparisons for the given item.
+     *
+     * @param itemComparison The item comparison
+     * @return  The html fragment comparisons
+     */
+    List<HtmlComparison> getComparisons(ItemComparison itemComparison);
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonContext.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonContext.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This model represents the current context of the comparison provider.
+ */
+@Data
+public class ItemTypeHtmlComparisonContext {
+
+    private String itemType;
+    private String language;
+    private List<HtmlComparison> comparisons = new ArrayList<>();
+
+    public Optional<String> getItemType() {
+        return Optional.ofNullable(itemType);
+    }
+
+    public Optional<String> getLanguage() {
+        return Optional.ofNullable(language);
+    }
+
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonContext.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonContext.java
@@ -4,7 +4,6 @@ import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This model represents the current context of the comparison provider.
@@ -15,13 +14,5 @@ public class ItemTypeHtmlComparisonContext {
     private String itemType;
     private String language;
     private List<HtmlComparison> comparisons = new ArrayList<>();
-
-    public Optional<String> getItemType() {
-        return Optional.ofNullable(itemType);
-    }
-
-    public Optional<String> getLanguage() {
-        return Optional.ofNullable(language);
-    }
 
 }

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonProvider.java
@@ -1,0 +1,52 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+
+/**
+ * Implementations of this interface are responsible for
+ * handling a single item type (MC, EQ, MI, etc)
+ * and providing located HTML comparison fragments.
+ */
+public interface ItemTypeHtmlComparisonProvider {
+
+    /**
+     * Provide comparisons for the root ItemRelease object.
+     *
+     * @param context       The comparison context
+     * @param sourceRelease The source item release
+     * @param testRelease   The test item release
+     */
+    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
+                                   final ItemRelease sourceRelease,
+                                   final ItemRelease testRelease) {
+    }
+
+    /**
+     * Provide comparisons for the Item object.
+     * NOTE: the {@link ItemTypeHtmlComparisonContext#getItemType()} will
+     * be initialized with the content language.
+     *
+     * @param context       The comparison context
+     * @param sourceItem    The source item
+     * @param testItem      The test item
+     */
+    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
+                                   final ItemRelease.Item sourceItem,
+                                   final ItemRelease.Item testItem) {
+    }
+
+    /**
+     * Provide comparisons for the Content object.
+     * NOTE: the {@link ItemTypeHtmlComparisonContext#getLanguage()} will
+     * be initialized with the content language.
+     *
+     * @param context       The comparison context
+     * @param sourceContent The source content
+     * @param testContent   The test content
+     */
+    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
+                                   final ItemRelease.Item.Content sourceContent,
+                                   final ItemRelease.Item.Content testContent) {
+    }
+
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/ItemTypeHtmlComparisonProvider.java
@@ -10,43 +10,14 @@ import org.opentestsystem.ap.common.saaif.item.ItemRelease;
 public interface ItemTypeHtmlComparisonProvider {
 
     /**
-     * Provide comparisons for the root ItemRelease object.
-     *
-     * @param context       The comparison context
-     * @param sourceRelease The source item release
-     * @param testRelease   The test item release
-     */
-    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
-                                   final ItemRelease sourceRelease,
-                                   final ItemRelease testRelease) {
-    }
-
-    /**
-     * Provide comparisons for the Item object.
-     * NOTE: the {@link ItemTypeHtmlComparisonContext#getItemType()} will
-     * be initialized with the content language.
-     *
-     * @param context       The comparison context
-     * @param sourceItem    The source item
-     * @param testItem      The test item
-     */
-    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
-                                   final ItemRelease.Item sourceItem,
-                                   final ItemRelease.Item testItem) {
-    }
-
-    /**
      * Provide comparisons for the Content object.
-     * NOTE: the {@link ItemTypeHtmlComparisonContext#getLanguage()} will
-     * be initialized with the content language.
      *
      * @param context       The comparison context
      * @param sourceContent The source content
      * @param testContent   The test content
      */
-    default void appendComparisons(final ItemTypeHtmlComparisonContext context,
-                                   final ItemRelease.Item.Content sourceContent,
-                                   final ItemRelease.Item.Content testContent) {
-    }
+    void appendComparisons(final ItemTypeHtmlComparisonContext context,
+                           final ItemRelease.Item.Content sourceContent,
+                           final ItemRelease.Item.Content testContent);
 
 }

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/HtmlDifferenceProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/HtmlDifferenceProvider.java
@@ -1,0 +1,31 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.diff;
+
+import org.opentestsystem.ap.itemcompare.comparer.html.HtmlComparisonContext;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparison;
+import org.opentestsystem.ap.itemcompare.model.ItemDifference;
+
+import java.util.List;
+
+/**
+ * Implementations of this interface are responsible for
+ * analyzing an {@link HtmlComparison} and reporting differences.
+ */
+public interface HtmlDifferenceProvider {
+
+    /**
+     * Reportable HTML difference types
+     */
+    enum DifferenceType {
+        IMPORT_VALUE_NOT_FOUND,
+        TIMS_VALUE_NOT_FOUND,
+        TEXT_DIFFERENCE
+    }
+
+    /**
+     * Calculate the reportable differences in the given HTML comparison.
+     *
+     * @param comparisonDocuments   The html comparison documents
+     * @return  The differences between source and test html
+     */
+    List<ItemDifference> getDifferences(HtmlComparisonContext comparisonDocuments);
+}

--- a/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/TextHtmlDifferenceProvider.java
+++ b/src/main/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/TextHtmlDifferenceProvider.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.diff;
+
+import org.jsoup.nodes.Document;
+import org.opentestsystem.ap.itemcompare.comparer.html.HtmlComparisonContext;
+import org.opentestsystem.ap.itemcompare.model.ItemDifference;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This difference provider is responsible for reporting
+ * un-styled text differences between the source and test html.
+ *
+ * NOTE: This provider also reports on missing source or test HTML.
+ */
+@Component
+class TextHtmlDifferenceProvider implements HtmlDifferenceProvider {
+
+    @Override
+    public List<ItemDifference> getDifferences(final HtmlComparisonContext comparisonDocuments) {
+        if (!comparisonDocuments.getSourceDocument().isPresent() && !comparisonDocuments.getTestDocument().isPresent()) {
+            // No documents to compare
+            return Collections.emptyList();
+        }
+
+        final ItemDifference.ItemDifferenceBuilder builder = ItemDifference.builder()
+            .filename(comparisonDocuments.getFilename())
+            .location(comparisonDocuments.getComparison().getLocation());
+
+        if (!comparisonDocuments.getSourceDocument().isPresent()) {
+            return Collections.singletonList(builder
+                .differenceType(DifferenceType.IMPORT_VALUE_NOT_FOUND.name())
+                .testValue(getText(comparisonDocuments.getTestDocument().get()))
+                .build());
+        }
+
+        if (!comparisonDocuments.getTestDocument().isPresent()) {
+            return Collections.singletonList(builder
+                .differenceType(DifferenceType.TIMS_VALUE_NOT_FOUND.name())
+                .sourceValue(getText(comparisonDocuments.getSourceDocument().get()))
+                .build());
+        }
+
+        final String sourceText = getText(comparisonDocuments.getSourceDocument().get());
+        final String testText = getText(comparisonDocuments.getTestDocument().get());
+        if (sourceText.equals(testText)) return Collections.emptyList();
+
+        return Collections.singletonList(builder
+            .differenceType(DifferenceType.TEXT_DIFFERENCE.name())
+            .sourceValue(sourceText)
+            .testValue(testText)
+            .build());
+    }
+
+    private String getText(final Document document) {
+        return document.text()
+            .replaceAll("[\\s\\u00A0]+", " "); //Collapse whitespace including &nbsp;
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/itemcompare/CompareModelSupport.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/CompareModelSupport.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.itemcompare;
 
+import com.google.common.collect.ImmutableList;
 import org.opentestsystem.ap.common.saaif.item.ItemRelease;
 import org.opentestsystem.ap.itemcompare.model.CompareContext;
 import org.opentestsystem.ap.itemcompare.model.ItemComparison;
@@ -42,12 +43,24 @@ public class CompareModelSupport {
     public static ItemRelease releaseWithResources() {
         final ItemRelease.Item.MachineRubric rubric = mock(ItemRelease.Item.MachineRubric.class);
         when(rubric.getFilename()).thenReturn("Item_183704_v11.qrx");
+
         final ItemRelease.Item.RendererSpec rendererSpec = mock(ItemRelease.Item.RendererSpec.class);
         when(rendererSpec.getFilename()).thenReturn("Item_183704_v11.eax");
+
+        final ItemRelease.Item.Content englishContent = mock(ItemRelease.Item.Content.class, "English Content");
+        when(englishContent.getLanguage()).thenReturn("ENU");
+        when(englishContent.getStem()).thenReturn("<p>English Stem</p>");
+
+        final ItemRelease.Item.Content spanishContent = mock(ItemRelease.Item.Content.class, "Spanish Content");
+        when(spanishContent.getLanguage()).thenReturn("ESN");
+        when(spanishContent.getStem()).thenReturn("<p>Spanish Stem</p>");
+
         final ItemRelease.Item item = mock(ItemRelease.Item.class);
         when(item.getFormat()).thenReturn("eq");
         when(item.getMachineRubric()).thenReturn(Collections.singletonList(rubric));
         when(item.getRendererSpec()).thenReturn(Collections.singletonList(rendererSpec));
+        when(item.getContent()).thenReturn(ImmutableList.of(englishContent, spanishContent));
+
         final ItemRelease itemRelease = mock(ItemRelease.class);
         when(itemRelease.getItem()).thenReturn(item);
         return itemRelease;

--- a/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparerTest.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/ItemHtmlComparerTest.java
@@ -1,0 +1,149 @@
+package org.opentestsystem.ap.itemcompare.comparer.html;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparison;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparisonProvider;
+import org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider;
+import org.opentestsystem.ap.itemcompare.model.ItemComparison;
+import org.opentestsystem.ap.itemcompare.model.ItemDifference;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.itemcompare.CompareModelSupport.itemComparison;
+import static org.opentestsystem.ap.itemcompare.CompareModelSupport.itemDifference;
+import static org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider.DifferenceType.TEXT_DIFFERENCE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ItemHtmlComparerTest {
+
+    @Mock
+    private HtmlComparisonProvider comparisonProvider;
+
+    @Mock
+    private HtmlDifferenceProvider differenceProviderA;
+
+    @Mock
+    private HtmlDifferenceProvider differenceProviderB;
+
+    @Spy
+    private Set<HtmlDifferenceProvider> differenceProviders = new HashSet<>();
+
+    @InjectMocks
+    private ItemHtmlComparer comparer;
+
+    @Before
+    public void setup() {
+        differenceProviders.addAll(ImmutableSet.of(differenceProviderA, differenceProviderB));
+    }
+
+    @Test
+    public void itShouldCompareHtmlOnItems() {
+        final ItemComparison itemComparison = itemComparison("123");
+        final HtmlComparison htmlComparisonA = htmlComparison("A");
+        final HtmlComparison htmlComparisonB = htmlComparison("B");
+        when(comparisonProvider.getComparisons(itemComparison)).thenReturn(ImmutableList.of(htmlComparisonA, htmlComparisonB));
+
+        final ItemDifference itemDifferenceA = itemDifference(TEXT_DIFFERENCE.name());
+        when(differenceProviderA.getDifferences(any())).thenAnswer(invocation -> {
+            final HtmlComparisonContext context = invocation.getArgumentAt(0, HtmlComparisonContext.class);
+            if (context.getComparison() == htmlComparisonA) {
+                return ImmutableList.of(itemDifferenceA);
+            }
+            return emptyList();
+        });
+
+        final ItemDifference itemDifferenceB = itemDifference(TEXT_DIFFERENCE.name());
+        when(differenceProviderB.getDifferences(any())).thenAnswer(invocation -> {
+            final HtmlComparisonContext context = invocation.getArgumentAt(0, HtmlComparisonContext.class);
+            if (context.getComparison() == htmlComparisonB) {
+                return ImmutableList.of(itemDifferenceB);
+            }
+            return emptyList();
+        });
+
+        assertThat(comparer.compare(itemComparison)).containsOnly(itemDifferenceA, itemDifferenceB);
+    }
+
+    @Test
+    public void itShouldHandleMissingSourceHtml() {
+        final ItemComparison itemComparison = itemComparison("123");
+        final HtmlComparison htmlComparison = HtmlComparison.builder()
+            .location("Location")
+            .testHtml("<p>Test Html<p>")
+            .build();
+        when(comparisonProvider.getComparisons(itemComparison)).thenReturn(ImmutableList.of(htmlComparison));
+
+        when(differenceProviderA.getDifferences(any())).thenAnswer(invocation -> {
+            final HtmlComparisonContext context = invocation.getArgumentAt(0, HtmlComparisonContext.class);
+            assertThat(context.getSourceDocument().isPresent()).isFalse();
+            assertThat(context.getTestDocument().isPresent()).isTrue();
+            return Collections.emptyList();
+        });
+
+        assertThat(comparer.compare(itemComparison)).isEmpty();
+    }
+
+    @Test
+    public void itShouldHandleMissingTestHtml() {
+        final ItemComparison itemComparison = itemComparison("123");
+        final HtmlComparison htmlComparison = HtmlComparison.builder()
+            .location("Location")
+            .sourceHtml("<p>Source Html<p>")
+            .build();
+        when(comparisonProvider.getComparisons(itemComparison)).thenReturn(ImmutableList.of(htmlComparison));
+
+        when(differenceProviderA.getDifferences(any())).thenAnswer(invocation -> {
+            final HtmlComparisonContext context = invocation.getArgumentAt(0, HtmlComparisonContext.class);
+            assertThat(context.getSourceDocument().isPresent()).isTrue();
+            assertThat(context.getTestDocument().isPresent()).isFalse();
+            return Collections.emptyList();
+        });
+
+        assertThat(comparer.compare(itemComparison)).isEmpty();
+    }
+
+    @Test
+    public void itShouldHandleInvalidHtml() {
+        final ItemComparison itemComparison = itemComparison("123");
+        final HtmlComparison htmlComparison = HtmlComparison.builder()
+            .location("Location")
+            .sourceHtml("<p>Some <spin>bad</spin> <@#$>tags</@#$></p>")
+            .testHtml("<p>Some <spin<p<p<p>bad</spin> <!->tags</@#$><")
+            .build();
+        when(comparisonProvider.getComparisons(itemComparison)).thenReturn(ImmutableList.of(htmlComparison));
+
+        when(differenceProviderA.getDifferences(any())).thenAnswer(invocation -> {
+            final HtmlComparisonContext context = invocation.getArgumentAt(0, HtmlComparisonContext.class);
+            assertThat(context.getSourceDocument().isPresent()).isTrue();
+            assertThat(context.getSourceDocument().get().text()).isNotEmpty();
+
+            assertThat(context.getTestDocument().isPresent()).isTrue();
+            assertThat(context.getTestDocument().get().text()).isNotEmpty();
+            return Collections.emptyList();
+        });
+
+        assertThat(comparer.compare(itemComparison)).isEmpty();
+    }
+
+    private HtmlComparison htmlComparison(final String id) {
+        return HtmlComparison.builder()
+            .location("Location " + id)
+            .sourceHtml("<p>Source Html " + id + "</p>")
+            .testHtml("<p>Test Html " + id + "<p>")
+            .build();
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProviderTest.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProviderTest.java
@@ -1,0 +1,113 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+import org.opentestsystem.ap.itemcompare.CompareModelSupport;
+import org.opentestsystem.ap.itemcompare.model.ItemComparison;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultHtmlComparisonProviderTest {
+
+    @Mock
+    private ItemTypeHtmlComparisonProvider typeProviderA;
+
+    @Mock
+    private ItemTypeHtmlComparisonProvider typeProviderB;
+
+    @Spy
+    private Set<ItemTypeHtmlComparisonProvider> typeProviders = new HashSet<>();
+
+    @InjectMocks
+    private DefaultHtmlComparisonProvider provider;
+
+    @Before
+    public void setup() {
+        typeProviders.addAll(ImmutableSet.of(typeProviderA, typeProviderB));
+    }
+
+    @Test
+    public void itShouldCallTypeProvidersWithItemRelease() {
+        final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
+
+        provider.getComparisons(itemComparison);
+
+        verify(typeProviderA).appendComparisons(
+            any(),
+            eq(itemComparison.getSource().getItemRelease()),
+            eq(itemComparison.getTest().getItemRelease()));
+        verify(typeProviderB).appendComparisons(
+            any(),
+            eq(itemComparison.getSource().getItemRelease()),
+            eq(itemComparison.getTest().getItemRelease()));
+    }
+
+    @Test
+    public void itShouldCallTypeProvidersWithItem() {
+        final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
+        final ItemRelease.Item sourceItem = itemComparison.getSource().getItemRelease().getItem();
+        final ItemRelease.Item testItem = itemComparison.getTest().getItemRelease().getItem();
+
+        provider.getComparisons(itemComparison);
+
+        final ArgumentCaptor<ItemTypeHtmlComparisonContext> contextCaptor = ArgumentCaptor.forClass(ItemTypeHtmlComparisonContext.class);
+        verify(typeProviderA).appendComparisons(
+            contextCaptor.capture(),
+            eq(sourceItem),
+            eq(testItem));
+        verify(typeProviderB).appendComparisons(
+            any(),
+            eq(sourceItem),
+            eq(testItem));
+
+        final ItemTypeHtmlComparisonContext context = contextCaptor.getValue();
+        assertThat(context.getItemType().isPresent()).isTrue();
+        assertThat(context.getItemType().get()).isEqualTo(sourceItem.getFormat());
+    }
+
+    @Test
+    public void itShouldCallTypeProvidersAllLanguageContent() {
+        final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
+
+        doAnswer(invocation -> {
+            final ItemTypeHtmlComparisonContext context = invocation.getArgumentAt(0, ItemTypeHtmlComparisonContext.class);
+            final ItemRelease.Item.Content sourceContent = invocation.getArgumentAt(1, ItemRelease.Item.Content.class);
+            final ItemRelease.Item.Content testContent = invocation.getArgumentAt(2, ItemRelease.Item.Content.class);
+
+            assertThat(sourceContent.getLanguage()).isEqualTo(testContent.getLanguage());
+            if ("English".equals(context.getLanguage().get())) {
+                assertThat(sourceContent.getLanguage()).isEqualTo("ENU");
+            } else if ("Spanish".equals(context.getLanguage().get())) {
+                assertThat(sourceContent.getLanguage()).isEqualTo("ESN");
+            } else {
+                fail("Unknown language: " + context.getLanguage().get());
+            }
+
+            return null;
+        }).when(typeProviderA).appendComparisons(any(), any(ItemRelease.Item.Content.class), any(ItemRelease.Item.Content.class));
+
+        provider.getComparisons(itemComparison);
+
+        verify(typeProviderA, times(2)).appendComparisons(any(), any(ItemRelease.Item.Content.class), any());
+        verify(typeProviderB, times(2)).appendComparisons(any(), any(ItemRelease.Item.Content.class), any());
+    }
+
+}

--- a/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProviderTest.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/DefaultHtmlComparisonProviderTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -19,7 +18,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,45 +43,6 @@ public class DefaultHtmlComparisonProviderTest {
     }
 
     @Test
-    public void itShouldCallTypeProvidersWithItemRelease() {
-        final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
-
-        provider.getComparisons(itemComparison);
-
-        verify(typeProviderA).appendComparisons(
-            any(),
-            eq(itemComparison.getSource().getItemRelease()),
-            eq(itemComparison.getTest().getItemRelease()));
-        verify(typeProviderB).appendComparisons(
-            any(),
-            eq(itemComparison.getSource().getItemRelease()),
-            eq(itemComparison.getTest().getItemRelease()));
-    }
-
-    @Test
-    public void itShouldCallTypeProvidersWithItem() {
-        final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
-        final ItemRelease.Item sourceItem = itemComparison.getSource().getItemRelease().getItem();
-        final ItemRelease.Item testItem = itemComparison.getTest().getItemRelease().getItem();
-
-        provider.getComparisons(itemComparison);
-
-        final ArgumentCaptor<ItemTypeHtmlComparisonContext> contextCaptor = ArgumentCaptor.forClass(ItemTypeHtmlComparisonContext.class);
-        verify(typeProviderA).appendComparisons(
-            contextCaptor.capture(),
-            eq(sourceItem),
-            eq(testItem));
-        verify(typeProviderB).appendComparisons(
-            any(),
-            eq(sourceItem),
-            eq(testItem));
-
-        final ItemTypeHtmlComparisonContext context = contextCaptor.getValue();
-        assertThat(context.getItemType().isPresent()).isTrue();
-        assertThat(context.getItemType().get()).isEqualTo(sourceItem.getFormat());
-    }
-
-    @Test
     public void itShouldCallTypeProvidersAllLanguageContent() {
         final ItemComparison itemComparison = CompareModelSupport.itemComparison("123");
 
@@ -93,12 +52,12 @@ public class DefaultHtmlComparisonProviderTest {
             final ItemRelease.Item.Content testContent = invocation.getArgumentAt(2, ItemRelease.Item.Content.class);
 
             assertThat(sourceContent.getLanguage()).isEqualTo(testContent.getLanguage());
-            if ("English".equals(context.getLanguage().get())) {
+            if ("English".equals(context.getLanguage())) {
                 assertThat(sourceContent.getLanguage()).isEqualTo("ENU");
-            } else if ("Spanish".equals(context.getLanguage().get())) {
+            } else if ("Spanish".equals(context.getLanguage())) {
                 assertThat(sourceContent.getLanguage()).isEqualTo("ESN");
             } else {
-                fail("Unknown language: " + context.getLanguage().get());
+                fail("Unknown language: " + context.getLanguage());
             }
 
             return null;

--- a/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProviderTest.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/comparison/GeneralItemTypeHtmlComparisonProviderTest.java
@@ -1,0 +1,74 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.comparison;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.common.saaif.item.ItemRelease;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneralItemTypeHtmlComparisonProviderTest {
+
+    private ItemTypeHtmlComparisonContext context;
+
+    @InjectMocks
+    private GeneralItemTypeHtmlComparisonProvider provider;
+
+    @Before
+    public void setup() {
+        context = new ItemTypeHtmlComparisonContext();
+        context.setLanguage("Language");
+        context.setItemType("mc");
+    }
+
+    @Test
+    public void itShouldProvideAStemHtmlComparison() {
+        final ItemRelease.Item.Content sourceContent = mockContent(1);
+        final ItemRelease.Item.Content testContent = mockContent(2);
+
+        provider.appendComparisons(context, sourceContent, testContent);
+        assertThat(context.getComparisons()).hasSize(1);
+
+        final HtmlComparison comparison = context.getComparisons().get(0);
+        assertThat(comparison.getLocation()).isEqualTo("Language Prompt");
+        assertThat(comparison.getSourceHtml().orElse("")).isEqualTo("stem 1");
+        assertThat(comparison.getTestHtml().orElse("")).isEqualTo("stem 2");
+    }
+
+    @Test
+    public void itShouldHandleMissingSourceContent() {
+        final ItemRelease.Item.Content testContent = mockContent(2);
+
+        provider.appendComparisons(context, null, testContent);
+        assertThat(context.getComparisons()).hasSize(1);
+
+        final HtmlComparison comparison = context.getComparisons().get(0);
+        assertThat(comparison.getLocation()).isEqualTo("Language Prompt");
+        assertThat(comparison.getSourceHtml().isPresent()).isFalse();
+        assertThat(comparison.getTestHtml().orElse("")).isEqualTo("stem 2");
+    }
+
+    @Test
+    public void itShouldHandleMissingTestContent() {
+        final ItemRelease.Item.Content sourceContent = mockContent(1);
+
+        provider.appendComparisons(context, sourceContent, null);
+        assertThat(context.getComparisons()).hasSize(1);
+
+        final HtmlComparison comparison = context.getComparisons().get(0);
+        assertThat(comparison.getLocation()).isEqualTo("Language Prompt");
+        assertThat(comparison.getSourceHtml().orElse("")).isEqualTo("stem 1");
+        assertThat(comparison.getTestHtml().isPresent()).isFalse();
+    }
+
+    private ItemRelease.Item.Content mockContent(final int id) {
+        final ItemRelease.Item.Content content = mock(ItemRelease.Item.Content.class);
+        when(content.getStem()).thenReturn("stem " + id);
+        return content;
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/TextHtmlDifferenceProviderTest.java
+++ b/src/test/java/org/opentestsystem/ap/itemcompare/comparer/html/diff/TextHtmlDifferenceProviderTest.java
@@ -1,0 +1,111 @@
+package org.opentestsystem.ap.itemcompare.comparer.html.diff;
+
+import org.jsoup.Jsoup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.itemcompare.comparer.html.HtmlComparisonContext;
+import org.opentestsystem.ap.itemcompare.comparer.html.comparison.HtmlComparison;
+import org.opentestsystem.ap.itemcompare.model.ItemDifference;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider.DifferenceType.IMPORT_VALUE_NOT_FOUND;
+import static org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider.DifferenceType.TEXT_DIFFERENCE;
+import static org.opentestsystem.ap.itemcompare.comparer.html.diff.HtmlDifferenceProvider.DifferenceType.TIMS_VALUE_NOT_FOUND;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TextHtmlDifferenceProviderTest {
+    private static final String ComplexHtml = "<p>TEST: You <span id=\"item_183704_TAG_1\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"1\"></span>would also like<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_1\" data-tag-boundary=\"end\"></span> your <span id=\"item_183704_TAG_2\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"7\"></span>room<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_2\" data-tag-boundary=\"end\"></span> <span id=\"item_183704_TAG_3\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"6\"></span>painted<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_3\" data-tag-boundary=\"end\"></span>.</p><p>Your <span id=\"item_183704_TAG_4\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"7\"></span>room<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_4\" data-tag-boundary=\"end\"></span> has <span id=\"item_183704_TAG_1_BEGIN\">300</span> square feet of <span id=\"item_183704_TAG_5\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"2\"></span>wall<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_5\" data-tag-boundary=\"end\"></span> <span id=\"item_183704_TAG_6\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"3\"></span>space<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_6\" data-tag-boundary=\"end\"></span> <span id=\"item_183704_TAG_7\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"8\"></span>to paint<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_7\" data-tag-boundary=\"end\"></span>.</p><p>Sam says <span id=\"item_183704_TAG_8\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"4\"></span>it took<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_8\" data-tag-boundary=\"end\"></span> her 10 minutes <span id=\"item_183704_TAG_9\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"8\"></span>to paint<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_9\" data-tag-boundary=\"end\"></span> 25 square feet.</p><br /><p><span style=\"letter-spacing:normal;\">At this rate, if Sam <span id=\"item_183704_TAG_10\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"6\"></span>painted<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_10\" data-tag-boundary=\"end\"></span> your <span id=\"item_183704_TAG_11\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"7\"></span>room<span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_11\" data-tag-boundary=\"end\"></span>, how many </span><strong><span id=\"item_183704_TAG_2_BEGIN\"><span style=\"letter-spacing:normal;\">hours</span></span></strong><span style=\"letter-spacing:normal;\"> would it&#xA0;</span><span id=\"item_183704_TAG_1\" class=\"its-tag\" data-tag=\"word\" data-tag-boundary=\"start\" data-word-index=\"5\"></span><span id=\"item_183704_TAG_0_BEGIN\">take</span><span class=\"its-tag\" data-tag-ref=\"item_183704_TAG_1\" data-tag-boundary=\"end\"></span>?</p>";
+    private static final String SimpleHtml = "<p>Some <b>simple <u>html</u></b>.</p>";
+    private static final String SimpleText = "Some simple html.";
+
+    @InjectMocks
+    private TextHtmlDifferenceProvider provider;
+
+    @Test
+    public void itShouldNotReportADifferenceInComplexHtml() {
+        final HtmlComparisonContext documents = documents(ComplexHtml, ComplexHtml);
+        assertThat(provider.getDifferences(documents)).isEmpty();
+    }
+
+    @Test
+    public void itShouldNotReportStyleDifferences() {
+        final String sourceHtml = "<p>Some <span style=\"text-decoration:underline\">text</span> content.</p>";
+        final String testHtml = "<p>Some <u>text</u> content.</p>";
+
+        assertThat(provider.getDifferences(documents(sourceHtml, testHtml))).isEmpty();
+    }
+
+    @Test
+    public void itShouldNotReportAnEmptyDifference() {
+        assertThat(provider.getDifferences(documents(null, null))).isEmpty();
+    }
+
+    @Test
+    public void itShouldReportMissingSourceText() {
+        final HtmlComparisonContext documents = documents(null, SimpleHtml);
+        final List<ItemDifference> differences = provider.getDifferences(documents);
+
+        assertThat(differences).hasSize(1);
+        final ItemDifference difference = differences.get(0);
+        assertThat(difference.getDifferenceType()).isEqualTo(IMPORT_VALUE_NOT_FOUND.name());
+        assertThat(difference.getFilename()).isEqualTo(documents.getFilename());
+        assertThat(difference.getLocation()).isEqualTo(documents.getComparison().getLocation());
+        assertThat(difference.getSourceValue()).isNull();
+        assertThat(difference.getTestValue()).isEqualTo(SimpleText);
+    }
+
+    @Test
+    public void itShouldReportMissingTestText() {
+        final HtmlComparisonContext documents = documents(SimpleHtml, null);
+        final List<ItemDifference> differences = provider.getDifferences(documents);
+
+        assertThat(differences).hasSize(1);
+        final ItemDifference difference = differences.get(0);
+        assertThat(difference.getDifferenceType()).isEqualTo(TIMS_VALUE_NOT_FOUND.name());
+        assertThat(difference.getFilename()).isEqualTo(documents.getFilename());
+        assertThat(difference.getLocation()).isEqualTo(documents.getComparison().getLocation());
+        assertThat(difference.getSourceValue()).isEqualTo(SimpleText);
+        assertThat(difference.getTestValue()).isNull();
+    }
+
+    @Test
+    public void itShouldReportATextDifference() {
+        final String sourceHtml = "<p>Source <b>Value</b></p>";
+        final String testHtml = "<p>Test <b>Value</b></p>";
+        final HtmlComparisonContext documents = documents(sourceHtml, testHtml);
+        final List<ItemDifference> differences = provider.getDifferences(documents);
+
+        assertThat(differences).hasSize(1);
+        final ItemDifference difference = differences.get(0);
+        assertThat(difference.getDifferenceType()).isEqualTo(TEXT_DIFFERENCE.name());
+        assertThat(difference.getFilename()).isEqualTo(documents.getFilename());
+        assertThat(difference.getLocation()).isEqualTo(documents.getComparison().getLocation());
+        assertThat(difference.getSourceValue()).isEqualTo("Source Value");
+        assertThat(difference.getTestValue()).isEqualTo("Test Value");
+    }
+
+    @Test
+    public void itShouldCollapseMultipleSpacesIncludingNonBreakingSpaces() {
+        final String sourceHtml = "<p>Test\u00a0<b>Value</b></p>";
+        final String testHtml = "<p>Test   <b>Value</b></p>";
+        assertThat(provider.getDifferences(documents(sourceHtml, testHtml))).isEmpty();
+    }
+
+    private HtmlComparisonContext documents(final String sourceHtml, final String testHtml) {
+        final HtmlComparison comparison = HtmlComparison.builder()
+            .location("Somewhere")
+            .sourceHtml(sourceHtml)
+            .testHtml(testHtml)
+            .build();
+        return HtmlComparisonContext.builder()
+            .comparison(comparison)
+            .filename("filename.xml")
+            .sourceDocument(sourceHtml == null ? null : Jsoup.parseBodyFragment(sourceHtml))
+            .testDocument(testHtml == null ? null : Jsoup.parseBodyFragment(testHtml))
+            .build();
+    }
+}


### PR DESCRIPTION
The general process for comparing HTML contents between items is:
1. Find all of the HTML text values to compare between source/import and test/tims for an item (HtmlComparisonProvider implementations)
2. Parse the HTML text into JSoup HTML Documents
3. Run the HTML Documents through all difference detectors (HtmlDifferenceProvider implementations)

Right now the only HtmlComparisonProvider is a general implementation that provides the English and Spanish Spec/Prompt HTML.

Right now the only HtmlDifferenceProvider is a simple unstyled-text difference reporter that collapses whitespace before checking if the source text and test text are different.

Still TODO:
1. We need to provide *all* HTML text values for comparison (MI, MC, EQ, etc implementations of HtmlComparisonProvider)
2. We need to detect style differences between source and test HTML. (Bold/Italic/Underlined/Size/etc detection in a new HtmlDifferenceProvider implementation)